### PR TITLE
Let toVTK and toCSV continue in case of errors

### DIFF
--- a/tools/setup-openradioss.sh
+++ b/tools/setup-openradioss.sh
@@ -17,14 +17,13 @@ toVTK() {
 
     if [ $# -lt 1 ]; then
         echo "ERROR - Usage: toVTK ROOTNAME"
-        return 1
     fi
 
     Rootname="$1"
 
     for file in "${Rootname}"A*; do
         # skip if no matching files
-        [ -e "$file" ] || { echo "ERROR: No files matching ${Rootname}A*"; return 1; }
+        [ -e "$file" ] || { echo "ERROR: No files matching ${Rootname}A*"; }
 
         animation_number="${file#"${Rootname}A"}"
 
@@ -39,14 +38,13 @@ toCSV() {
 
     if [ $# -lt 1 ]; then
         echo "ERROR - Usage: toVTK ROOTNAME"
-        return 1
     fi
 
     Rootname="$1"
 
     for file in "${Rootname}"T*; do
         # skip if no matching files
-        [ -e "$file" ] || { echo "ERROR: No files matching ${Rootname}T*"; return 1; }
+        [ -e "$file" ] || { echo "ERROR: No files matching ${Rootname}T*"; }
 
         history_number="${file#"${Rootname}T"}"
 


### PR DESCRIPTION
Changes:

- Removes the `set -e -u`, which makes the script exit on error or undefined variables. (the `run.sh` has this anyway)
- Adds a clear `ERROR:` in the messages.
- Unrelated by suggested by shellcheck: replaced `"` by `'` in the aliases, even though this was already working with either.
- Removes the `return 1` statements.

Related to #8 (but I don't know if it actually closes it).