### PR TITLE
Add watchpoints and scripts to plot them

### DIFF
--- a/partitioned-beam-forces/plot-watchpoints.sh
+++ b/partitioned-beam-forces/plot-watchpoints.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+EXPERIMENT="uni-directional (forces), dt=0.01"
+
+FILE1="./beam-right-openradioss/precice-Beam-Right-watchpoint-Watchpoint-Right-Upper.log"
+TITLE1="R: Forces.y at y=0.4"
+
+FILE2="./beam-right-openradioss/precice-Beam-Right-watchpoint-Watchpoint-Right-Lower.log"
+TITLE2="R: Forces.y at y=0.1"
+
+FILE3="./beam-left-openradioss/precice-Beam-Left-watchpoint-Watchpoint-Left-Upper.log"
+TITLE3="L: Forces.y at y=0.4"
+
+FILE4="./beam-left-openradioss/precice-Beam-Left-watchpoint-Watchpoint-Left-Lower.log"
+TITLE4="L: Forces.y at y=0.1"
+
+gnuplot -p << EOF                                                               
+	set grid                                                                        
+	set title 'FORCES (y-component) - $EXPERIMENT'
+	set xlabel 'time [s]'
+	set ylabel 'x-displacement [m]'
+  set term pngcairo enhanced size 900,654
+  set output "images/watchpoints.png"
+	plot [0.0:3.0] \
+       "$FILE1" using 1:6 with lines title "$TITLE1",\
+       "$FILE2" using 1:6 with lines title "$TITLE2",\
+       "$FILE3" using 1:6 with lines title "$TITLE3",\
+       "$FILE4" using 1:6 with lines title "$TITLE4"
+EOF

--- a/partitioned-beam-forces/precice-config.xml
+++ b/partitioned-beam-forces/precice-config.xml
@@ -21,6 +21,8 @@
     <provide-mesh name="Beam-Left-Mesh" />
     <write-data name="FORCES" mesh="Beam-Left-Mesh" />
     <export:vtu directory="precice-exports" every-n-time-windows="100" />
+    <watch-point mesh="Beam-Left-Mesh" name="Watchpoint-Left-Upper" coordinate="0.25; 0.4; 6.0"/>
+    <watch-point mesh="Beam-Left-Mesh" name="Watchpoint-Left-Lower" coordinate="0.25; 0.1; 6.0"/>
   </participant>
 
   <participant name="Beam-Right">
@@ -33,13 +35,15 @@
       to="Beam-Right-Mesh"
       constraint="consistent" />
     <export:vtu directory="precice-exports" every-n-time-windows="100" />
+    <watch-point mesh="Beam-Right-Mesh" name="Watchpoint-Right-Upper" coordinate="0.25; 0.4; 6.0"/>
+    <watch-point mesh="Beam-Right-Mesh" name="Watchpoint-Right-Lower" coordinate="0.25; 0.1; 6.0"/>
   </participant>
 
   <m2n:sockets acceptor="Beam-Right" connector="Beam-Left" exchange-directory=".." />
 
   <coupling-scheme:parallel-explicit>
     <participants first="Beam-Right" second="Beam-Left" />
-    <max-time-windows value="300" />
+    <max-time value="3.0" />
     <time-window-size value="1e-2" />
     <exchange data="FORCES" mesh="Beam-Left-Mesh" from="Beam-Left" to="Beam-Right" />
   </coupling-scheme:parallel-explicit>


### PR DESCRIPTION
This PR adds [watchpoints](https://precice.org/configuration-watchpoint.html) to the following cases:

- [x] partitioned-beam-forces
- [ ] partitioned-beam-displacements
- [ ] partitioned-beam-bidirectional

It also adds a configurable script `plot-watchpoints.sh` that plots them and writes images into `images/`.

To make things clearer in experiments, I am also changing from `max-time-windows` to `max-time`.