### PR TITLE
Watchpoints plots: Fix ylabel

### DIFF
--- a/partitioned-beam-forces/plot-watchpoints.sh
+++ b/partitioned-beam-forces/plot-watchpoints.sh
@@ -18,7 +18,7 @@ gnuplot -p << EOF
 	set grid                                                                        
 	set title 'FORCES (y-component) - $EXPERIMENT'
 	set xlabel 'time [s]'
-	set ylabel 'FORCES (y-component)'
+	set ylabel 'FORCES (y-component) [N]'
   set term pngcairo enhanced size 900,654
   set output "images/watchpoints.png"
 	plot [0.0:3.0] \


### PR DESCRIPTION
Fixes the y-label of the watchpoint plot script in the `partitioned-beam-forces` case.

@elisa-santoro I am not sure what unit OpenRadioss uses here, feel free to suggest an edit on this line to add it.